### PR TITLE
Readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,40 @@
-# ![#FF9900](https://placehold.it/25x50/FF9900/000000?text=+) Paneled Outlier Explorer - Brushable Plots
+# Paneled Outlier Explorer - Brushable Plots
 
+![alt tag](https://user-images.githubusercontent.com/31038805/30431689-649b02c6-992d-11e7-8497-b4091829652b.gif)
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;![alt tag](https://user-images.githubusercontent.com/31038805/30431689-649b02c6-992d-11e7-8497-b4091829652b.gif)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;![#FF9900](https://placehold.it/15x300/FF9900/000000?text=+)
+## Overview 
 
-### The Paneled Outlier Explorer is a javascript library that provides paneled line charts of data points over time with point and line brushing. 
+The Paneled Outlier Explorer is a javascript library that provides paneled line charts of data points over time with point and line brushing. It is designed for use in clinical trial research, but can also be applied in other areas. 
 
-
- 
 The paneled outlier explorer is closely related to the (non-paneled) [safety outlier explorer](https://github.com/RhoInc/safety-outlier-explorer) library, and can be used to monitor key safety signals in clinical trials in conjunction with other charts in the [safety explorer suite](https://github.com/RhoInc/safety-explorer-suite). 
 
 The Paneled Outlier Explorer includes interactive features such as real-time brushing and requires minimal user configuration.
 [Click here for a live demo](https://rhoinc.github.io/viz-library/examples/0019-paneled-outlier-explorer/example.html). When the page loads, the user sees multiple paneled charts providing a lab data summary for each measure over time.
 
-&nbsp;
-&nbsp;
+[alt tag](https://user-images.githubusercontent.com/31038805/30434209-a96d443e-9934-11e7-95a9-d2525491bad7.gif)
 
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;![#FF9900](https://placehold.it/15x375/FF9900/000000?text=+)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;![alt tag](https://user-images.githubusercontent.com/31038805/30434209-a96d443e-9934-11e7-95a9-d2525491bad7.gif)
+## Usage
 
-
-Generally speaking, minimal configuration is needed to create a Paneled Outlier Explorer. 
-
-### Just [load a json data set](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Data-Guidelines) and the tool will automatically create a user interface (measures, etc.) based on the data set loaded. 
+Generally speaking, minimal configuration is needed to create a Paneled Outlier Explorer. Just [load a json data set](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Data-Guidelines) and the tool will automatically create a user interface (measures, etc.) based on the data set loaded. 
 
 Initialize the chart like so: 
 ```javascript
 paneledOutlierExplorer('body', {}).init(data)
 ```
-### Our [API](https://github.com/RhoInc/paneled-outlier-explorer/wiki/API) also offers custom [configuraton](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration) settings: 
+
+Our [API](https://github.com/RhoInc/paneled-outlier-explorer/wiki/API) also offers custom [configuraton](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration) settings: 
 | Param | Type | Description |
 | --- | --- | --- |
 | element | `string` | CSS selector identifying the element in which to create the chart |
 | settings| `object` | settings object specifying chart appearance and behavior; options defined here overwrite defaults; see [Configuration](Configuration) |
 
 
-### See this example: [Paneled Outlier Explorer](https://rhoinc.github.io/viz-library/examples/0019-paneled-outlier-explorer/example.html)
+### Links 
 
-For even more information see:
+More information is available in the project's [wiki](https://github.com/RhoInc/paneled-outlier-explorer/wiki/): 
 
+- [Interactive Example](https://rhoinc.github.io/viz-library/examples/0019-paneled-outlier-explorer/example.html)
+- [Configuration](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration) 
 - [Technical Documentation](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Technical-Documentation) 
-&nbsp;
 - [Data Guidelines](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Data-Guidelines). 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ var settings = {
 paneledOutlierExplorer('body', settings).init(data)
 ```
 
-### Links 
+## Links 
 
 More information is available in the project's [wiki](https://github.com/RhoInc/paneled-outlier-explorer/wiki/): 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paneled Outlier Explorer - Brushable Plots
+# Paneled Outlier Explorer
 
 ![alt tag](https://user-images.githubusercontent.com/31038805/30431689-649b02c6-992d-11e7-8497-b4091829652b.gif)
 
@@ -11,8 +11,7 @@ The paneled outlier explorer is closely related to the (non-paneled) [safety out
 The Paneled Outlier Explorer includes interactive features such as real-time brushing and requires minimal user configuration.
 [Click here for a live demo](https://rhoinc.github.io/viz-library/examples/0019-paneled-outlier-explorer/example.html). When the page loads, the user sees multiple paneled charts providing a lab data summary for each measure over time.
 
-[alt tag](https://user-images.githubusercontent.com/31038805/30434209-a96d443e-9934-11e7-95a9-d2525491bad7.gif)
-
+![alt tag](https://user-images.githubusercontent.com/31038805/30434209-a96d443e-9934-11e7-95a9-d2525491bad7.gif)
 
 ## Usage
 
@@ -23,12 +22,21 @@ Initialize the chart like so:
 paneledOutlierExplorer('body', {}).init(data)
 ```
 
-Our [API](https://github.com/RhoInc/paneled-outlier-explorer/wiki/API) also offers custom [configuraton](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration) settings: 
-| Param | Type | Description |
-| --- | --- | --- |
-| element | `string` | CSS selector identifying the element in which to create the chart |
-| settings| `object` | settings object specifying chart appearance and behavior; options defined here overwrite defaults; see [Configuration](Configuration) |
+Creating a chart with a basic [custom configuration](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration)would look like this: 
 
+```javascript
+var settings = {
+  "id_col":"custom_id_variable",
+  "filters":[
+    {
+      "value_col":"GENDER",
+      "label":"Gender"
+    }
+  ]
+}
+
+paneledOutlierExplorer('body', settings).init(data)
+```
 
 ### Links 
 
@@ -36,5 +44,6 @@ More information is available in the project's [wiki](https://github.com/RhoInc/
 
 - [Interactive Example](https://rhoinc.github.io/viz-library/examples/0019-paneled-outlier-explorer/example.html)
 - [Configuration](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration) 
+- [API](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration)
 - [Technical Documentation](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Technical-Documentation) 
 - [Data Guidelines](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Data-Guidelines). 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Initialize the chart like so:
 paneledOutlierExplorer('body', {}).init(data)
 ```
 
-Creating a chart with a basic [custom configuration](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration)would look like this: 
+Creating a chart with a basic [custom configuration](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration) would look like this: 
 
 ```javascript
 var settings = {

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ More information is available in the project's [wiki](https://github.com/RhoInc/
 - [Configuration](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration) 
 - [API](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration)
 - [Technical Documentation](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Technical-Documentation) 
-- [Data Guidelines](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Data-Guidelines). 
+- [Data Guidelines](https://github.com/RhoInc/paneled-outlier-explorer/wiki/Data-Guidelines)


### PR DESCRIPTION
Streamlined the readme a bit and also updated the [wiki home page](https://github.com/RhoInc/paneled-outlier-explorer/wiki) to avoid overlap. Tried to set the overall structure of both to be fairly general so that they can be re-used in the other safety explorer plots. 